### PR TITLE
[chore] update frontend CI/CD workflows

### DIFF
--- a/.github/workflows/front-cd.yaml
+++ b/.github/workflows/front-cd.yaml
@@ -32,7 +32,7 @@ jobs:
           name: frontend-build
           path: ./artifact
           run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
 
       # 2. 다운로드 확인
       - name: List downloaded files
@@ -47,8 +47,9 @@ jobs:
           host: ${{ secrets.FE_HOST }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          source: "./artifact/*"
+          source: "artifact/**"
           target: "/home/ubuntu/fe/incoming/release"
+          strip_components: 1
 
       # 4. 배포 스크립트 실행
       - name: Execute FE Deploy Script
@@ -84,11 +85,10 @@ jobs:
           curl -X POST -H "Content-Type: application/json" \
           -d "{
             \"embeds\": [{
-              \"title\": \"FE 배포 결과 (artifact 기반)\",
+              \"title\": \"FE CD 결과\",
               \"description\": \"**상태**: ${STATUS}\\n**브랜치**: ${BRANCH}\\n**담당자**: ${ACTOR}\",
               \"color\": ${COLOR},
               \"fields\": [
-                {\"name\": \"커밋\", \"value\": \"${SHA}\"},
                 {\"name\": \"커밋 메시지\", \"value\": \"${COMMIT_MSG}\"},
                 {\"name\": \"로그\", \"value\": \"${RUN_URL}\"}
               ]

--- a/.github/workflows/front-ci.yaml
+++ b/.github/workflows/front-ci.yaml
@@ -103,6 +103,10 @@ jobs:
           OUT="$(echo $OUT | xargs)"
           echo "paths=$OUT" >> $GITHUB_OUTPUT
           echo "Detected: $OUT"
+          if [ -z "$OUT" ]; then
+            echo "ERROR: No build output directory found (dist/build/.next)"
+            exit 1
+          fi
 
       # 12. artifact 업로드 (main / develop)
       - name: Upload Artifact
@@ -146,7 +150,6 @@ jobs:
               \"description\": \"**상태**: ${STATUS}\\n**이벤트**: ${EVENT}\\n**브랜치**: ${BRANCH}\\n**담당자**: ${ACTOR}\",
               \"color\": ${COLOR},
               \"fields\": [
-                {\"name\": \"SHA\", \"value\": \"${SHA}\"},
                 {\"name\": \"커밋 메시지\", \"value\": \"${COMMIT_MSG_ESCAPED}\"},
                 {\"name\": \"로그\", \"value\": \"${RUN_URL}\"}
               ]


### PR DESCRIPTION
## #️⃣ 연관된 이슈

## 📝 작업 내용
- Frontend CI → CD 파이프라인 구성 및 artifact 기반 배포 흐름 정리
   - 배포 실패 원인 분석 및 CI/CD 산출물 디렉터리 구조 불일치 문제 확인

## 📸 스크린샷 (선택)
<img width="100%" alt="image" src="https://github.com/user-attachments/assets/3d405b0c-6359-4a9f-a2da-7163131e16b9" />


## 📢 참고 사항
- EC2 배포 스크립트는 /fe/incoming/release 경로에 index.html이 바로 존재한다고 가정
   - 실제로는 artifact 내부(artifact/dist/index.html)에 존재하여 배포가 실패함
   - 추후 CI artifact 구조 조정 또는 deploy.sh 수정 필요
