### PR TITLE
[revert] front workflows 146, 147

### DIFF
--- a/.github/workflows/front-cd.yaml
+++ b/.github/workflows/front-cd.yaml
@@ -7,10 +7,18 @@ on:
         description: 'Branch name from caller workflow'
         required: true
         type: string
+      run_id:
+        description: 'Caller workflow run ID to fetch artifacts'
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       ref_name:
         description: 'Branch name to deploy'
+        required: true
+        type: string
+      run_id:
+        description: 'CI workflow run ID to fetch artifacts'
         required: true
         type: string
 
@@ -38,6 +46,7 @@ jobs:
         with:
           name: frontend-build
           path: ./artifact
+          run-id: ${{ inputs.run_id }}
           github-token: ${{ github.token }}
 
       # 2. 다운로드 확인

--- a/.github/workflows/front-cd.yaml
+++ b/.github/workflows/front-cd.yaml
@@ -7,18 +7,10 @@ on:
         description: 'Branch name from caller workflow'
         required: true
         type: string
-      run_id:
-        description: 'Caller workflow run ID to fetch artifacts'
-        required: true
-        type: string
   workflow_dispatch:
     inputs:
       ref_name:
         description: 'Branch name to deploy'
-        required: true
-        type: string
-      run_id:
-        description: 'CI workflow run ID to fetch artifacts'
         required: true
         type: string
 
@@ -46,7 +38,6 @@ jobs:
         with:
           name: frontend-build
           path: ./artifact
-          run-id: ${{ inputs.run_id }}
           github-token: ${{ github.token }}
 
       # 2. 다운로드 확인

--- a/.github/workflows/front-ci.yaml
+++ b/.github/workflows/front-ci.yaml
@@ -180,4 +180,3 @@ jobs:
     secrets: inherit
     with:
       ref_name: ${{ github.ref_name }}
-      run_id: ${{ github.run_id }}


### PR DESCRIPTION
## 📝 작업 내용
- PR #146에서 반영된 frontend workflow 복원 변경사항을 revert 했습니다.
- PR #147에서 반영된 `run_id` 전달 관련 workflow 변경사항을 revert 했습니다.
- 결과적으로 FE 배포 워크플로를 기존 `develop`의 S3 + CloudFront 기준 동작으로 되돌렸습니다.

## 📢 참고 사항
- 이번 PR은 `.github/workflows/front-ci.yaml`, `.github/workflows/front-cd.yaml`만 대상으로 한 리버트입니다.
- 애플리케이션 소스 코드(프론트 비즈니스 로직) 변경은 없습니다.
- merge 후 `develop`에서 Actions 재실행하여 배포 흐름 확인 부탁드립니다.
