### PR TITLE
[Revert] front workflows 146, 147

### DIFF
--- a/.github/workflows/front-cd.yaml
+++ b/.github/workflows/front-cd.yaml
@@ -7,10 +7,18 @@ on:
         description: 'Branch name from caller workflow'
         required: true
         type: string
+      run_id:
+        description: 'Caller workflow run ID to fetch artifacts'
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       ref_name:
         description: 'Branch name to deploy'
+        required: true
+        type: string
+      run_id:
+        description: 'CI workflow run ID to fetch artifacts'
         required: true
         type: string
 
@@ -38,6 +46,7 @@ jobs:
         with:
           name: frontend-build
           path: ./artifact
+          run-id: ${{ inputs.run_id }}
           github-token: ${{ github.token }}
 
       # 2. 다운로드 확인

--- a/.github/workflows/front-cd.yaml
+++ b/.github/workflows/front-cd.yaml
@@ -7,18 +7,10 @@ on:
         description: 'Branch name from caller workflow'
         required: true
         type: string
-      run_id:
-        description: 'Caller workflow run ID to fetch artifacts'
-        required: true
-        type: string
   workflow_dispatch:
     inputs:
       ref_name:
         description: 'Branch name to deploy'
-        required: true
-        type: string
-      run_id:
-        description: 'CI workflow run ID to fetch artifacts'
         required: true
         type: string
 
@@ -46,7 +38,6 @@ jobs:
         with:
           name: frontend-build
           path: ./artifact
-          run-id: ${{ inputs.run_id }}
           github-token: ${{ github.token }}
 
       # 2. 다운로드 확인

--- a/.github/workflows/front-cd.yaml
+++ b/.github/workflows/front-cd.yaml
@@ -117,12 +117,20 @@ jobs:
       # 8. Discord 알림
       - name: Notify Discord
         if: always()
+        env:
+          COMMIT_MSG_RAW: ${{ github.event.head_commit.message }}
         run: |
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           BRANCH="${{ inputs.ref_name }}"
           SHA="${{ github.sha }}"
           ACTOR="${{ github.actor }}"
-          COMMIT_MSG="${{ github.event.head_commit.message }}"
+          COMMIT_MSG="${COMMIT_MSG_RAW}"
+
+          if [ -z "$COMMIT_MSG" ]; then
+            COMMIT_MSG="(커밋 메시지를 이벤트에서 가져올 수 없음)"
+          fi
+
+          COMMIT_MSG_ESCAPED="$(printf '%s' "$COMMIT_MSG" | sed 's/\\/\\\\/g; s/\"/\\\"/g')"
 
           if [ "${{ job.status }}" = "success" ]; then
             STATUS="성공"
@@ -139,7 +147,7 @@ jobs:
               \"description\": \"**상태**: ${STATUS}\\n**브랜치**: ${BRANCH}\\n**담당자**: ${ACTOR}\",
               \"color\": ${COLOR},
               \"fields\": [
-                {\"name\": \"커밋 메시지\", \"value\": \"${COMMIT_MSG}\"},
+                {\"name\": \"커밋 메시지\", \"value\": \"${COMMIT_MSG_ESCAPED}\"},
                 {\"name\": \"로그\", \"value\": \"${RUN_URL}\"}
               ]
             }]

--- a/.github/workflows/front-ci.yaml
+++ b/.github/workflows/front-ci.yaml
@@ -180,4 +180,3 @@ jobs:
     secrets: inherit
     with:
       ref_name: ${{ github.ref_name }}
-      run_id: ${{ github.run_id }}

--- a/.github/workflows/front-ci.yaml
+++ b/.github/workflows/front-ci.yaml
@@ -138,13 +138,15 @@ jobs:
       # 13. Discord 알림 (항상)
       - name: Notify Discord (always)
         if: always()
+        env:
+          COMMIT_MSG_RAW: ${{ github.event.head_commit.message }}
         run: |
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           BRANCH="${{ github.ref_name }}"
           EVENT="${{ github.event_name }}"
           ACTOR="${{ github.actor }}"
           SHA="${{ github.sha }}"
-          COMMIT_MSG="${{ github.event.head_commit.message }}"
+          COMMIT_MSG="${COMMIT_MSG_RAW}"
 
           if [ -z "$COMMIT_MSG" ]; then
             COMMIT_MSG="(커밋 메시지를 이벤트에서 가져올 수 없음)"


### PR DESCRIPTION
## 📝 작업 내용
- PR #146, #147에서 반영된 frontend workflow 변경사항을 revert 했습니다.
- `.github/workflows/front-ci.yaml`에서 `deploy` 호출 시 `run_id` 전달 로직을 제거해 기존 호출 방식으로 복원했습니다.
- `.github/workflows/front-cd.yaml`을 `develop`의 S3 + CloudFront 배포 흐름 기준으로 복원했습니다.
- CI/CD Discord 알림 단계에서 커밋 메시지에 따옴표(`"`)가 포함돼도 실패하지 않도록 문자열 처리 방식을 보완했습니다.
  - `github.event.head_commit.message`를 `env`로 전달
  - 빈 메시지 fallback 추가
  - JSON escape 처리 적용

## 📢 참고 사항
- 이번 PR은 `.github/workflows/front-ci.yaml`, `.github/workflows/front-cd.yaml`만 변경했습니다.
- 애플리케이션 소스 코드/비즈니스 로직 변경은 없습니다.
