### PR TITLE
[fix] main FE workflow 복구 (S3 + CloudFront)

### DIFF
--- a/.github/workflows/front-cd.yaml
+++ b/.github/workflows/front-cd.yaml
@@ -117,12 +117,20 @@ jobs:
       # 8. Discord 알림
       - name: Notify Discord
         if: always()
+        env:
+          COMMIT_MSG_RAW: ${{ github.event.head_commit.message }}
         run: |
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           BRANCH="${{ inputs.ref_name }}"
           SHA="${{ github.sha }}"
           ACTOR="${{ github.actor }}"
-          COMMIT_MSG="${{ github.event.head_commit.message }}"
+          COMMIT_MSG="${COMMIT_MSG_RAW}"
+
+          if [ -z "$COMMIT_MSG" ]; then
+            COMMIT_MSG="(커밋 메시지를 이벤트에서 가져올 수 없음)"
+          fi
+
+          COMMIT_MSG_ESCAPED="$(printf '%s' "$COMMIT_MSG" | sed 's/\\/\\\\/g; s/\"/\\\"/g')"
 
           if [ "${{ job.status }}" = "success" ]; then
             STATUS="성공"
@@ -139,7 +147,7 @@ jobs:
               \"description\": \"**상태**: ${STATUS}\\n**브랜치**: ${BRANCH}\\n**담당자**: ${ACTOR}\",
               \"color\": ${COLOR},
               \"fields\": [
-                {\"name\": \"커밋 메시지\", \"value\": \"${COMMIT_MSG}\"},
+                {\"name\": \"커밋 메시지\", \"value\": \"${COMMIT_MSG_ESCAPED}\"},
                 {\"name\": \"로그\", \"value\": \"${RUN_URL}\"}
               ]
             }]

--- a/.github/workflows/front-ci.yaml
+++ b/.github/workflows/front-ci.yaml
@@ -138,13 +138,15 @@ jobs:
       # 13. Discord 알림 (항상)
       - name: Notify Discord (always)
         if: always()
+        env:
+          COMMIT_MSG_RAW: ${{ github.event.head_commit.message }}
         run: |
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           BRANCH="${{ github.ref_name }}"
           EVENT="${{ github.event_name }}"
           ACTOR="${{ github.actor }}"
           SHA="${{ github.sha }}"
-          COMMIT_MSG="${{ github.event.head_commit.message }}"
+          COMMIT_MSG="${COMMIT_MSG_RAW}"
 
           if [ -z "$COMMIT_MSG" ]; then
             COMMIT_MSG="(커밋 메시지를 이벤트에서 가져올 수 없음)"
@@ -180,4 +182,3 @@ jobs:
     secrets: inherit
     with:
       ref_name: ${{ github.ref_name }}
-      run_id: ${{ github.run_id }}


### PR DESCRIPTION
## 📝 작업 내용

- `main` 브랜치 기준 FE 워크플로를 `develop`의 정상 동작 상태(S3 + CloudFront 배포 경로)로 맞췄습니다.
- `.github/workflows/front-ci.yaml`에서 `deploy` 호출 시 `run_id` 전달을 제거해 현재 `front-cd.yaml` 인터페이스와 일치시켰습니다.
- `.github/workflows/front-ci.yaml`, `.github/workflows/front-cd.yaml`의 Discord 알림 단계에서 따옴표가 포함된 커밋 메시지로 인한 스크립트 실패를 방지하도록 문자열 처리(`env` 전달 + escape)를 보완했습니다.

## 📢 참고 사항

- 이번 PR은 워크플로 파일 2개만 수정했습니다.
  - `.github/workflows/front-ci.yaml`
  - `.github/workflows/front-cd.yaml`
- 애플리케이션 소스 코드 및 기능 로직 변경은 없습니다.
- 기존 `develop -> main` 대규모 PR 대신, `main` 기준 최소 변경 PR로 분리한 건입니다.
