### PR TITLE
[fix] 배포를 dev S3+CloudFront 대상으로 통일

### DIFF
--- a/.github/workflows/front-cd.yaml
+++ b/.github/workflows/front-cd.yaml
@@ -24,10 +24,9 @@ concurrency:
 
 jobs:
   deploy:
-    # develop 자동 배포, main은 수동 실행일 때만 배포
+    # develop/main push 모두 배포 허용
     if: >
-      inputs.ref_name == 'develop' ||
-      (github.event_name == 'workflow_dispatch' && inputs.ref_name == 'main')
+      inputs.ref_name == 'develop' || inputs.ref_name == 'main'
 
     runs-on: ubuntu-latest
 
@@ -73,15 +72,11 @@ jobs:
         env:
           REF_NAME: ${{ inputs.ref_name }}
           FE_S3_BUCKET_DEV: ${{ secrets.FE_S3_BUCKET_DEV }}
-          FE_S3_BUCKET_PROD: ${{ secrets.FE_S3_BUCKET_PROD }}
           FE_CF_DIST_DEV: ${{ secrets.FE_CF_DIST_DEV }}
         run: |
           set -euo pipefail
-          if [ "$REF_NAME" = "develop" ]; then
+          if [ "$REF_NAME" = "develop" ] || [ "$REF_NAME" = "main" ]; then
             BUCKET="$FE_S3_BUCKET_DEV"
-            DIST_ID="$FE_CF_DIST_DEV"
-          elif [ "$REF_NAME" = "main" ]; then
-            BUCKET="$FE_S3_BUCKET_PROD"
             DIST_ID="$FE_CF_DIST_DEV"
           else
             echo "Unsupported ref_name for deploy: $REF_NAME"


### PR DESCRIPTION
## 📝 작업 내용
- CD 워크플로우에서 `develop`, `main` 브랜치 모두 배포 가능하도록 조건을 수정했습니다.
- 기존 `main` 전용 분기(`FE_S3_BUCKET_PROD`)를 제거해 배포 경로를 단순화했습니다.
- 변경 파일: `.github/workflows/front-cd.yaml`

## 📢 참고 사항
- yml 변경입니다.
- 현재 `codoc.cloud`가 바라보는 CloudFront/S3 기준으로 `develop`, `main` 모두 동일한 배포 결과를 내도록 설정했습니다.
