### PR TITLE
[update] frontend CI/CD flow for dev and prod deployment

### DIFF
--- a/.github/workflows/front-cd.yaml
+++ b/.github/workflows/front-cd.yaml
@@ -4,13 +4,11 @@ on:
   workflow_call:
     inputs:
       ref_name:
-        description: 'Branch name from caller workflow'
         required: true
         type: string
   workflow_dispatch:
     inputs:
       ref_name:
-        description: 'Branch name to deploy'
         required: true
         type: string
 
@@ -19,137 +17,133 @@ permissions:
   actions: read
 
 concurrency:
-  group: frontend-cd-s3-cloudfront
-  cancel-in-progress: true
+  group: frontend-cd
+  cancel-in-progress: false
 
 jobs:
-  deploy:
-    # develop 자동 배포, main은 수동 실행일 때만 배포
-    if: >
-      inputs.ref_name == 'develop' ||
-      (github.event_name == 'workflow_dispatch' && inputs.ref_name == 'main')
 
+  deploy-dev:
+    if: inputs.ref_name == 'develop'
     runs-on: ubuntu-latest
 
     steps:
-      # 1. CI artifact 다운로드
-      - name: Download FE Artifact (from CI run)
+      - name: Download artifact
         uses: actions/download-artifact@v4
         with:
           name: frontend-build
           path: ./artifact
-          github-token: ${{ github.token }}
 
-      # 2. 다운로드 확인
-      - name: List downloaded files
-        run: |
-          echo "Downloaded artifact:"
-          find ./artifact -maxdepth 3 -type f | head -n 200
+      - name: Clean release dir on EC2
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.DEV_HOST }}
+          username: ubuntu
+          key: ${{ secrets.DEV_SSH_KEY }}
+          script: |
+            rm -rf /home/ubuntu/frontend-release/*
 
-      # 3. 빌드 산출물 폴더 탐지
-      - name: Detect build output folder
-        id: out
-        run: |
-          OUT=""
-          [ -d artifact/dist ] && OUT="artifact/dist"
-          [ -z "$OUT" ] && [ -d artifact/build ] && OUT="artifact/build"
-          [ -z "$OUT" ] && [ -d artifact/.next ] && OUT="artifact/.next"
-          # download-artifact가 폴더 없이 루트에 바로 풀리는 경우 대응
-          if [ -z "$OUT" ] && [ -f artifact/index.html ]; then
-            OUT="artifact"
-          fi
-          if [ -z "$OUT" ]; then
-            echo "ERROR: No build output found under artifact/ (dist/build/.next)"
-            echo "Artifact directory snapshot:"
-            find artifact -maxdepth 3 -mindepth 1 -print | head -n 200 || true
-            exit 1
-          fi
-          echo "path=$OUT" >> $GITHUB_OUTPUT
-          echo "Detected output: $OUT"
+      - name: Upload to EC2
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.DEV_HOST }}
+          username: ubuntu
+          key: ${{ secrets.DEV_SSH_KEY }}
+          source: "artifact/**"
+          target: "/home/ubuntu/frontend-release"
+          strip_components: 1
 
-      # 4. 배포 대상(bucket/distribution) 선택
-      - name: Resolve deploy target
-        id: target
-        env:
-          REF_NAME: ${{ inputs.ref_name }}
-          FE_S3_BUCKET_DEV: ${{ secrets.FE_S3_BUCKET_DEV }}
-          FE_S3_BUCKET_PROD: ${{ secrets.FE_S3_BUCKET_PROD }}
-          FE_CF_DIST_DEV: ${{ secrets.FE_CF_DIST_DEV }}
+      - name: Deploy on EC2
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.DEV_HOST }}
+          username: ubuntu
+          key: ${{ secrets.DEV_SSH_KEY }}
+          script: |
+            sudo rm -rf /var/www/current/*
+            sudo cp -r /home/ubuntu/frontend-release/* /var/www/current/
+
+      - name: Health check dev
         run: |
-          set -euo pipefail
-          if [ "$REF_NAME" = "develop" ]; then
-            BUCKET="$FE_S3_BUCKET_DEV"
-            DIST_ID="$FE_CF_DIST_DEV"
-          elif [ "$REF_NAME" = "main" ]; then
-            BUCKET="$FE_S3_BUCKET_PROD"
-            DIST_ID="$FE_CF_DIST_DEV"
+          curl --fail --silent --show-error https://dev.codoc.cloud/ > /dev/null
+
+      - name: Notify CD result to Discord
+        if: always()
+        run: |
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          if [ "${{ job.status }}" = "success" ]; then
+            STATUS="success"
+            COLOR="65280"
           else
-            echo "Unsupported ref_name for deploy: $REF_NAME"
-            exit 1
+            STATUS="failure"
+            COLOR="16711680"
           fi
 
-          [ -n "$BUCKET" ] || (echo "Missing S3 bucket secret" && exit 1)
-          [ -n "$DIST_ID" ] || (echo "Missing CloudFront distribution secret" && exit 1)
+          curl -X POST -H "Content-Type: application/json" \
+            -d "{
+              \"embeds\": [{
+                \"title\": \"[FE] CD result\",
+                \"description\": \"Status: ${STATUS}\\nBranch: develop\\nTarget: https://dev.codoc.cloud/\",
+                \"color\": ${COLOR},
+                \"fields\": [
+                  {\"name\": \"Run\", \"value\": \"${RUN_URL}\"}
+                ]
+              }]
+            }" \
+            "${{ secrets.DISCORD_WEBHOOK }}"
 
-          echo "bucket=$BUCKET" >> $GITHUB_OUTPUT
-          echo "dist_id=$DIST_ID" >> $GITHUB_OUTPUT
+  deploy-prod:
+    if: inputs.ref_name == 'main'
+    runs-on: ubuntu-latest
 
-      # 5. AWS 자격증명 설정
-      - name: Configure AWS credentials
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-build
+          path: ./artifact
+
+      - name: Configure AWS
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ap-northeast-2
 
-      # 6. S3 배포
-      - name: Sync build to S3
+      - name: Deploy to S3
         run: |
-          aws s3 sync "${{ steps.out.outputs.path }}/" "s3://${{ steps.target.outputs.bucket }}" --delete
+          aws s3 sync artifact/ s3://${{ secrets.FE_S3_BUCKET_PROD }} --delete
 
-      # 7. CloudFront 무효화
-      - name: Invalidate CloudFront
+      - name: CloudFront invalidation
         run: |
           aws cloudfront create-invalidation \
-            --distribution-id "${{ steps.target.outputs.dist_id }}" \
+            --distribution-id ${{ secrets.FE_CF_DIST_PROD }} \
             --paths "/*"
 
-      # 8. Discord 알림
-      - name: Notify Discord
-        if: always()
-        env:
-          COMMIT_MSG_RAW: ${{ github.event.head_commit.message }}
+      - name: Health check prod
         run: |
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          BRANCH="${{ inputs.ref_name }}"
-          SHA="${{ github.sha }}"
-          ACTOR="${{ github.actor }}"
-          COMMIT_MSG="${COMMIT_MSG_RAW}"
+          curl --fail --silent --show-error https://codoc.cloud/ > /dev/null
 
-          if [ -z "$COMMIT_MSG" ]; then
-            COMMIT_MSG="(커밋 메시지를 이벤트에서 가져올 수 없음)"
-          fi
-
-          COMMIT_MSG_ESCAPED="$(printf '%s' "$COMMIT_MSG" | sed 's/\\/\\\\/g; s/\"/\\\"/g')"
-
+      - name: Notify CD result to Discord
+        if: always()
+        run: |
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           if [ "${{ job.status }}" = "success" ]; then
-            STATUS="성공"
+            STATUS="success"
             COLOR="65280"
           else
-            STATUS="실패"
+            STATUS="failure"
             COLOR="16711680"
           fi
 
           curl -X POST -H "Content-Type: application/json" \
-          -d "{
-            \"embeds\": [{
-              \"title\": \"[FE] CD 결과 알림\",
-              \"description\": \"**상태**: ${STATUS}\\n**브랜치**: ${BRANCH}\\n**담당자**: ${ACTOR}\",
-              \"color\": ${COLOR},
-              \"fields\": [
-                {\"name\": \"커밋 메시지\", \"value\": \"${COMMIT_MSG_ESCAPED}\"},
-                {\"name\": \"로그\", \"value\": \"${RUN_URL}\"}
-              ]
-            }]
-          }" \
-          ${{ secrets.DISCORD_WEBHOOK }}
+            -d "{
+              \"embeds\": [{
+                \"title\": \"[FE] CD result\",
+                \"description\": \"Status: ${STATUS}\\nBranch: main\\nTarget: https://codoc.cloud/\",
+                \"color\": ${COLOR},
+                \"fields\": [
+                  {\"name\": \"Run\", \"value\": \"${RUN_URL}\"}
+                ]
+              }]
+            }" \
+            "${{ secrets.DISCORD_WEBHOOK }}"

--- a/.github/workflows/front-ci.yaml
+++ b/.github/workflows/front-ci.yaml
@@ -1,66 +1,56 @@
 name: frontend-ci
 
 on:
-  # 1) PR이 develop/main으로 들어올 때: 품질 게이트(병합 전 검증)
   pull_request:
     branches: [develop, main]
 
-  # 2) main/develop 브랜치에 push될 때: 테스트용 빌드 + artifact 업로드
   push:
-    branches: [main, develop]
+    branches: [develop, main]
 
-  # 3) 필요하면 수동 실행
   workflow_dispatch: {}
 
 permissions:
   contents: read
   actions: read
 
-# 같은 PR/브랜치에서 커밋이 연속으로 올라오면
-# 이전 실행을 취소하고 최신 커밋만 검증해서 CI 낭비를 줄임
 concurrency:
-  group: frontend-ci-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: frontend-ci
+  cancel-in-progress: false
 
 jobs:
   verify:
     runs-on: ubuntu-latest
 
     steps:
-      # 1. 레포 코드 체크아웃
       - name: Checkout
         uses: actions/checkout@v4
 
-      # 2. Node 20 환경 구성 + npm 캐시 사용
-      - name: Setup Node.js (20)
+      - name: Setup Node 20
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: package-lock.json
+          node-version: "20"
+          cache: "npm"
 
-      # 3. 의존성 설치
-      - name: Install
+      - name: Install deps
         env:
           HUSKY: 0
         run: npm ci
 
-      # 4. ESLint 검사
       - name: Lint
         if: github.event_name == 'push'
-        run: npm run lint
+        run: npm run lint --if-present
 
-      # 5. Prettier 포맷 체크 (warn-only)
-      - name: Format Check (warn-only)
+      - name: Format check
         continue-on-error: true
-        run: npm run format:check
+        run: npm run format:check --if-present
 
-      # 6. 타입체크 (있으면)
       - name: Typecheck
         run: npm run typecheck --if-present
 
-      # 7. 의존성 취약점 검사
-      - name: Dependency Audit (warn-only)
+      - name: Test
+        run: npm test --if-present
+
+      - name: Dependency audit (warn-only)
         id: audit
         continue-on-error: true
         run: |
@@ -77,107 +67,84 @@ jobs:
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `high=${high}\ncritical=${critical}\n`);
           NODE
 
-      # 8. audit 경고 알림
-      - name: Notify Audit (Discord)
+      - name: Notify audit warning to Discord
         if: steps.audit.outputs.high != '0' || steps.audit.outputs.critical != '0'
         run: |
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           curl -X POST -H "Content-Type: application/json" \
-          -d "{\"content\":\"⚠️ **Frontend Audit 경고 (warn-only)**\\nHigh: ${{ steps.audit.outputs.high }} / Critical: ${{ steps.audit.outputs.critical }}\\nRepo: ${{ github.repository }}\\nRef: ${{ github.ref }}\\nActor: ${{ github.actor }}\\nRun: ${RUN_URL}\"}" \
-          ${{ secrets.DISCORD_WEBHOOK }}
+            -d "{\"content\":\"⚠️ Frontend audit warning\\nHigh: ${{ steps.audit.outputs.high }} / Critical: ${{ steps.audit.outputs.critical }}\\nRepo: ${{ github.repository }}\\nRef: ${{ github.ref }}\\nActor: ${{ github.actor }}\\nRun: ${RUN_URL}\"}" \
+            "${{ secrets.DISCORD_WEBHOOK }}"
 
-      # 9. 테스트 (있으면)
-      - name: Test
-        run: npm test --if-present
-
-      # 10. 빌드타임 .env 주입
-      - name: Prepare .env (build-time)
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
+      - name: Inject build env
         env:
-          FE_ENV: ${{ secrets.FE_ENV }}
+          FE_ENV: ${{ ((github.event_name == 'pull_request' && github.base_ref == 'main') || (github.event_name == 'push' && github.ref_name == 'main')) && secrets.FE_ENV_PROD || secrets.FE_ENV_DEV }}
         run: |
-          if [ -z "$FE_ENV" ]; then
-            echo "ERROR: FE_ENV secret is empty"
-            exit 1
-          fi
           printf '%s' "$FE_ENV" > .env
 
-      # 10. 빌드
       - name: Build
-        env:
-          # push 빌드에서 브랜치별 GA ID 주입
-          VITE_GA_ID: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.VITE_GA_ID_PROD || github.event_name == 'push' && github.ref == 'refs/heads/develop' && secrets.VITE_GA_ID_DEV || '' }}
         run: npm run build
 
-      # 11. 빌드 산출물 감지
       - name: Detect build output
         id: out
         run: |
-          OUT=""
-          [ -d dist ] && OUT="$OUT dist"
-          [ -d build ] && OUT="$OUT build"
-          [ -d .next ] && OUT="$OUT .next"
-          OUT="$(echo $OUT | xargs)"
-          echo "paths=$OUT" >> $GITHUB_OUTPUT
-          echo "Detected: $OUT"
-          if [ -z "$OUT" ]; then
-            echo "ERROR: No build output directory found (dist/build/.next)"
+          if [ -d dist ]; then
+            echo "path=dist" >> $GITHUB_OUTPUT
+          elif [ -d build ]; then
+            echo "path=build" >> $GITHUB_OUTPUT
+          else
+            echo "Build output not found"
             exit 1
           fi
 
-      # 12. artifact 업로드 (main / develop)
-      - name: Upload Artifact
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
+      - name: Upload artifact
+        if: github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:
           name: frontend-build
-          path: ${{ steps.out.outputs.paths }}
-          if-no-files-found: error
+          path: ${{ steps.out.outputs.path }}
           retention-days: 7
 
-      # 13. Discord 알림 (항상)
-      - name: Notify Discord (always)
+      - name: Notify CI result to Discord
         if: always()
         env:
           COMMIT_MSG_RAW: ${{ github.event.head_commit.message }}
         run: |
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           BRANCH="${{ github.ref_name }}"
-          EVENT="${{ github.event_name }}"
           ACTOR="${{ github.actor }}"
-          SHA="${{ github.sha }}"
           COMMIT_MSG="${COMMIT_MSG_RAW}"
 
           if [ -z "$COMMIT_MSG" ]; then
-            COMMIT_MSG="(커밋 메시지를 이벤트에서 가져올 수 없음)"
+            COMMIT_MSG="(commit message unavailable for this event)"
           fi
 
           COMMIT_MSG_ESCAPED="$(printf '%s' "$COMMIT_MSG" | sed 's/\\/\\\\/g; s/\"/\\\"/g')"
 
           if [ "${{ job.status }}" = "success" ]; then
-            STATUS="성공"
+            STATUS="success"
             COLOR="65280"
           else
-            STATUS="실패"
+            STATUS="failure"
             COLOR="16711680"
           fi
 
           curl -X POST -H "Content-Type: application/json" \
-          -d "{
-            \"embeds\": [{
-              \"title\": \"[FE] CI 결과 알림\",
-              \"description\": \"**상태**: ${STATUS}\\n**브랜치**: ${BRANCH}\\n**담당자**: ${ACTOR}\",
-              \"color\": ${COLOR},
-              \"fields\": [
-                {\"name\": \"커밋 메시지\", \"value\": \"${COMMIT_MSG_ESCAPED}\"},
-                {\"name\": \"로그\", \"value\": \"${RUN_URL}\"}
-              ]
-            }]
-          }" \
-          ${{ secrets.DISCORD_WEBHOOK }}
+            -d "{
+              \"embeds\": [{
+                \"title\": \"[FE] CI result\",
+                \"description\": \"Status: ${STATUS}\\nBranch: ${BRANCH}\\nActor: ${ACTOR}\",
+                \"color\": ${COLOR},
+                \"fields\": [
+                  {\"name\": \"Commit\", \"value\": \"${COMMIT_MSG_ESCAPED}\"},
+                  {\"name\": \"Run\", \"value\": \"${RUN_URL}\"}
+                ]
+              }]
+            }" \
+            "${{ secrets.DISCORD_WEBHOOK }}"
 
   deploy:
     needs: verify
+    if: github.event_name == 'push'
     uses: ./.github/workflows/front-cd.yaml
     secrets: inherit
     with:


### PR DESCRIPTION

## 📝 작업 내용

- 프론트 CI/CD 워크플로를 `develop` / `main` 배포 흐름에 맞게 정리했습니다.
- `develop` push 시 dev 서버(EC2)로 배포되고, `main` push 시 S3 업로드 후 CloudFront invalidation 되도록 구성했습니다.
- PR에서는 배포되지 않고 CI 검증만 수행하도록 유지했습니다.
- `FE_ENV_DEV` / `FE_ENV_PROD` 를 브랜치 기준으로 주입하도록 수정했습니다.
- CI/CD Discord 알림과 배포 후 `/` 기준 헬스체크를 추가했습니다.
- 실행 중인 워크플로가 새 push/PR로 취소되지 않도록 concurrency 설정을 조정했습니다.
- `workflow_dispatch` 를 다시 사용할 수 있도록 복구했습니다.
